### PR TITLE
Fix MicrosoftAI initialization bug and add scheduler configuration

### DIFF
--- a/tygent/integrations/microsoft_ai.py
+++ b/tygent/integrations/microsoft_ai.py
@@ -33,10 +33,23 @@ class MicrosoftAINode(LLMNode):
             prompt_template: Template string for the prompt
             dependencies: List of node names this node depends on
         """
-        super().__init__(name, dependencies=dependencies)
+        # LLMNode expects the underlying model to be passed as the ``model``
+        # argument.  The previous implementation attempted to forward the
+        # ``dependencies`` keyword directly to ``LLMNode`` which resulted in a
+        # ``TypeError`` because ``LLMNode.__init__`` does not accept that
+        # parameter.  Instead, pass the client as the model and apply
+        # dependencies separately.
+        super().__init__(name=name, model=client, prompt_template=prompt_template)
+
+        # Store configuration specific to this integration
         self.client = client
         self.deployment_id = deployment_id
         self.prompt_template = prompt_template
+
+        # Preserve any provided dependency information
+        if dependencies:
+            self.dependencies = dependencies
+
         self.kwargs = kwargs
 
     async def execute(


### PR DESCRIPTION
## Summary
- fix `MicrosoftAINode.__init__` so dependencies no longer raise an error
- provide `Scheduler.configure` and extend `Scheduler.execute` to accept either a DAG or just inputs

## Testing
- `pytest tests/integrations/test_microsoft_ai.py::TestMicrosoftAINode::test_initialization -q`
- `pytest tests/integrations/test_microsoft_ai.py::TestMicrosoftAINode::test_execute -q`
- `pytest tests/integrations/test_microsoft_ai.py -q`
- `pytest tests/test_dag.py::TestExecution::test_execution -q`
- `pytest tests/integrations/test_salesforce.py::TestSalesforceIntegration::test_create_query_node -q` *(fails: Lists differ)*
- `pytest tests/integrations/test_microsoft_ai.py::TestMicrosoftAIIntegration::test_optimize -q`


------
https://chatgpt.com/codex/tasks/task_e_685580be6ef0832ba18870b9dd15caf5