### PR TITLE
Remove lint job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,37 +35,10 @@ jobs:
       run: |
         pytest tests/ -v --tb=short || echo "Some integration tests may fail without API keys"
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 black mypy
-    
-    - name: Lint with flake8
-      run: |
-        flake8 tygent --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 tygent --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    
-    - name: Check formatting with black
-      run: |
-        black --check tygent/
-    
-    - name: Type check with mypy
-      run: |
-        mypy tygent/ --ignore-missing-imports || echo "Type checking completed with warnings"
 
   build:
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    needs: [test]
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
## Summary
- drop lint step from GitHub Actions workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858707b9cf0832bb4db054463691bf8