### PR TITLE
Add Claude, HF Hub, and LangSmith tests

### DIFF
--- a/tests/integrations/test_anthropic.py
+++ b/tests/integrations/test_anthropic.py
@@ -1,0 +1,83 @@
+"""Tests for Anthropic integration."""
+
+import unittest
+import pytest
+from tygent.integrations.anthropic import (
+    AnthropicNode,
+    AnthropicIntegration,
+    AnthropicBatchProcessor,
+)
+
+
+class MockClaudeMessages:
+    async def create(self, model, messages, max_tokens=256, temperature=0.7, **kwargs):
+        # Echo back the prompt content
+        content = messages[0]["content"]
+        return type("Resp", (), {"content": content})()
+
+
+class MockClaudeClient:
+    def __init__(self):
+        self.messages = MockClaudeMessages()
+
+
+class TestAnthropicNode(unittest.TestCase):
+    def setUp(self):
+        self.client = MockClaudeClient()
+        self.node = AnthropicNode(
+            name="test_node",
+            client=self.client,
+            prompt_template="Hello {name}",
+        )
+
+    def test_initialization(self):
+        self.assertEqual(self.node.name, "test_node")
+        self.assertEqual(self.node.model_name, "claude-3-opus-20240229")
+
+    @pytest.mark.asyncio
+    async def test_execute(self):
+        result = await self.node.execute({"name": "Alice"})
+        self.assertIn("Alice", result)
+
+
+class TestAnthropicIntegration(unittest.TestCase):
+    def setUp(self):
+        self.client = MockClaudeClient()
+        self.integration = AnthropicIntegration(self.client)
+
+    def test_add_node(self):
+        node = self.integration.add_node(
+            name="greet", prompt_template="Hi {who}", dependencies=[]
+        )
+        self.assertEqual(node.name, "greet")
+
+    @pytest.mark.asyncio
+    async def test_execute(self):
+        self.integration.add_node(name="greet", prompt_template="Hi {who}")
+        self.integration.add_node(
+            name="echo", prompt_template="{greet}", dependencies=["greet"]
+        )
+        results = await self.integration.execute({"who": "Bob"})
+        self.assertIn("greet", results)
+        self.assertIn("echo", results)
+
+
+class TestAnthropicBatchProcessor(unittest.TestCase):
+    def setUp(self):
+        self.client = MockClaudeClient()
+        self.processor = AnthropicBatchProcessor(
+            self.client, batch_size=2, max_concurrent_batches=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_process(self):
+        async def process_fn(prompt, client):
+            return prompt.upper()
+
+        prompts = ["a", "b", "c"]
+        results = await self.processor.process(prompts, process_fn)
+        self.assertEqual(results, ["A", "B", "C"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/test_huggingface.py
+++ b/tests/integrations/test_huggingface.py
@@ -1,0 +1,75 @@
+"""Tests for HuggingFace integration."""
+
+import unittest
+import pytest
+from tygent.integrations.huggingface import (
+    HuggingFaceNode,
+    HuggingFaceIntegration,
+    HuggingFaceBatchProcessor,
+)
+
+
+class MockHFModel:
+    def __call__(self, prompt, **kwargs):
+        return f"out:{prompt}"
+
+
+class TestHuggingFaceNode(unittest.TestCase):
+    def setUp(self):
+        self.model = MockHFModel()
+        self.node = HuggingFaceNode(
+            name="test_node",
+            model=self.model,
+            prompt_template="Hello {name}",
+        )
+
+    def test_initialization(self):
+        self.assertEqual(self.node.name, "test_node")
+
+    @pytest.mark.asyncio
+    async def test_execute(self):
+        result = await self.node.execute({"name": "Bob"})
+        self.assertIn("Bob", result)
+
+
+class TestHuggingFaceIntegration(unittest.TestCase):
+    def setUp(self):
+        self.model = MockHFModel()
+        self.integration = HuggingFaceIntegration(self.model)
+
+    def test_add_node(self):
+        node = self.integration.add_node(
+            name="greet", prompt_template="Hi {who}", dependencies=[]
+        )
+        self.assertEqual(node.name, "greet")
+
+    @pytest.mark.asyncio
+    async def test_execute(self):
+        self.integration.add_node(name="greet", prompt_template="Hi {who}")
+        self.integration.add_node(
+            name="echo", prompt_template="{greet}", dependencies=["greet"]
+        )
+        results = await self.integration.execute({"who": "Sam"})
+        self.assertIn("greet", results)
+        self.assertIn("echo", results)
+
+
+class TestHuggingFaceBatchProcessor(unittest.TestCase):
+    def setUp(self):
+        self.model = MockHFModel()
+        self.processor = HuggingFaceBatchProcessor(
+            self.model, batch_size=2, max_concurrent_batches=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_process(self):
+        async def process_fn(prompt, model):
+            return model(prompt)
+
+        prompts = ["a", "b", "c"]
+        results = await self.processor.process(prompts, process_fn)
+        self.assertEqual(results, ["out:a", "out:b", "out:c"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/test_langsmith.py
+++ b/tests/integrations/test_langsmith.py
@@ -1,0 +1,34 @@
+"""Tests for LangSmith tracker."""
+
+import unittest
+import pytest
+from tygent.integrations.langsmith import LangSmithTracker
+
+
+class MockLangSmithClient:
+    def __init__(self):
+        self.logged = []
+
+    async def log_run(self, dag_name, inputs, outputs, tags=None):
+        self.logged.append((dag_name, inputs, outputs, tags))
+
+
+class TestLangSmithTracker(unittest.TestCase):
+    def setUp(self):
+        self.client = MockLangSmithClient()
+        self.tracker = LangSmithTracker(self.client)
+
+    @pytest.mark.asyncio
+    async def test_log_run(self):
+        await self.tracker.log_run(
+            dag_name="demo",
+            inputs={"a": 1},
+            outputs={"b": 2},
+            tags=["t1"],
+        )
+        self.assertEqual(len(self.client.logged), 1)
+        self.assertEqual(self.client.logged[0][0], "demo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tygent/integrations/__init__.py
+++ b/tygent/integrations/__init__.py
@@ -45,6 +45,21 @@ try:
 except ImportError:
     pass
 
+try:
+    from .anthropic import AnthropicIntegration
+except ImportError:
+    pass
+
+try:
+    from .huggingface import HuggingFaceIntegration
+except ImportError:
+    pass
+
+try:
+    from .langsmith import LangSmithTracker
+except ImportError:
+    pass
+
 __all__ = [
     "LangChainIntegration",
     "OpenAIIntegration",
@@ -54,4 +69,7 @@ __all__ = [
     "AutoGenIntegration",
     "LangGraphIntegration",
     "CrewAIIntegration",
+    "AnthropicIntegration",
+    "HuggingFaceIntegration",
+    "LangSmithTracker",
 ]

--- a/tygent/integrations/anthropic.py
+++ b/tygent/integrations/anthropic.py
@@ -1,0 +1,143 @@
+"""
+Anthropic Claude Integration for Tygent.
+
+This module provides integration with Anthropic's Claude models for
+optimized DAG execution and batch processing.
+"""
+
+from typing import Any, Dict, List, Optional, Callable
+import asyncio
+
+try:
+    from anthropic import AsyncAnthropic
+except Exception:  # pragma: no cover - anthropic may not be installed
+    AsyncAnthropic = None  # type: ignore
+
+from ..dag import DAG
+from ..nodes import LLMNode
+from ..scheduler import Scheduler
+
+
+class AnthropicNode(LLMNode):
+    """Node for executing Anthropic Claude API calls."""
+
+    def __init__(
+        self,
+        name: str,
+        client: Any,
+        model: str = "claude-3-opus-20240229",
+        prompt_template: str = "",
+        dependencies: Optional[List[str]] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name=name, model=client, prompt_template=prompt_template)
+        self.client = client
+        self.model_name = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        if dependencies:
+            self.dependencies = dependencies
+        self.kwargs = kwargs
+
+    async def execute(self, inputs: Dict[str, Any]) -> Any:
+        prompt = self._format_prompt(inputs, {})
+        try:
+            if hasattr(self.client, "messages"):
+                response = await self.client.messages.create(
+                    model=self.model_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                    **self.kwargs,
+                )
+                if hasattr(response, "content"):
+                    content = response.content
+                    if isinstance(content, list):
+                        return "".join(
+                            part.text if hasattr(part, "text") else str(part)
+                            for part in content
+                        )
+                    return content
+                return response
+            else:
+                response = await self.client.completions.create(
+                    model=self.model_name,
+                    prompt=prompt,
+                    max_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                    **self.kwargs,
+                )
+                return getattr(response, "completion", response)
+        except Exception as e:  # pragma: no cover - runtime errors
+            print(f"Error executing Anthropic node {self.name}: {e}")
+            raise
+
+
+class AnthropicIntegration:
+    """Integration for Anthropic Claude models with Tygent's DAG system."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+        self.dag = DAG(name="anthropic_dag")
+        self.scheduler = Scheduler(self.dag)
+
+    def add_node(
+        self,
+        name: str,
+        prompt_template: str,
+        dependencies: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> AnthropicNode:
+        node = AnthropicNode(
+            name=name,
+            client=self.client,
+            prompt_template=prompt_template,
+            dependencies=dependencies,
+            **kwargs,
+        )
+        self.dag.add_node(node)
+        return node
+
+    def optimize(self, options: Dict[str, Any]) -> None:
+        if "maxParallelCalls" in options:
+            self.scheduler.max_parallel_nodes = options["maxParallelCalls"]
+        if "maxExecutionTime" in options:
+            self.scheduler.max_execution_time = options["maxExecutionTime"]
+        if "priorityNodes" in options:
+            self.scheduler.priority_nodes = options["priorityNodes"]
+
+    async def execute(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        return await self.scheduler.execute(inputs)
+
+
+class AnthropicBatchProcessor:
+    """Process lists of prompts with Anthropic's API in batches."""
+
+    def __init__(
+        self, client: Any, batch_size: int = 5, max_concurrent_batches: int = 2
+    ) -> None:
+        self.client = client
+        self.batch_size = batch_size
+        self.max_concurrent_batches = max_concurrent_batches
+
+    async def process(
+        self, prompts: List[str], process_fn: Callable[[str, Any], Any]
+    ) -> List[Any]:
+        batches = [
+            prompts[i : i + self.batch_size]
+            for i in range(0, len(prompts), self.batch_size)
+        ]
+        results: List[Any] = []
+        for i in range(0, len(batches), self.max_concurrent_batches):
+            current = batches[i : i + self.max_concurrent_batches]
+            tasks = [
+                asyncio.create_task(process_fn(p, self.client))
+                for batch in current
+                for p in batch
+            ]
+            batch_results = await asyncio.gather(*tasks, return_exceptions=True)
+            results.extend(r for r in batch_results if not isinstance(r, Exception))
+        return results
+

--- a/tygent/integrations/huggingface.py
+++ b/tygent/integrations/huggingface.py
@@ -1,0 +1,126 @@
+"""
+HuggingFace Hub Integration for Tygent.
+
+This module allows Tygent DAGs to use models hosted on HuggingFace Hub,
+with optional asynchronous generation and streaming support.
+"""
+
+from typing import Any, Dict, List, Optional, Callable
+import asyncio
+
+from ..dag import DAG
+from ..nodes import LLMNode
+from ..scheduler import Scheduler
+
+
+class HuggingFaceNode(LLMNode):
+    """Node for executing HuggingFace Hub models."""
+
+    def __init__(
+        self,
+        name: str,
+        model: Any,
+        prompt_template: str = "",
+        dependencies: Optional[List[str]] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name=name, model=model, prompt_template=prompt_template)
+        self.model = model
+        self.stream = stream
+        if dependencies:
+            self.dependencies = dependencies
+        self.kwargs = kwargs
+
+    async def execute(self, inputs: Dict[str, Any]) -> Any:
+        prompt = self._format_prompt(inputs, {})
+        try:
+            if self.stream and hasattr(self.model, "astream"):
+                chunks: List[str] = []
+                async for token in self.model.astream(prompt, **self.kwargs):
+                    chunks.append(str(token))
+                return "".join(chunks)
+            if hasattr(self.model, "__call__"):
+                if asyncio.iscoroutinefunction(self.model.__call__):
+                    return await self.model(prompt, **self.kwargs)
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(None, self.model, prompt, **self.kwargs)
+            if hasattr(self.model, "generate"):
+                if asyncio.iscoroutinefunction(self.model.generate):
+                    return await self.model.generate(prompt, **self.kwargs)
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(None, self.model.generate, prompt, **self.kwargs)
+            raise ValueError("Unsupported HuggingFace model")
+        except Exception as e:  # pragma: no cover - runtime errors
+            print(f"Error executing HuggingFace node {self.name}: {e}")
+            raise
+
+
+class HuggingFaceIntegration:
+    """Integration for HuggingFace Hub models with Tygent's DAG system."""
+
+    def __init__(self, model: Any) -> None:
+        self.model = model
+        self.dag = DAG(name="huggingface_dag")
+        self.scheduler = Scheduler(self.dag)
+
+    def add_node(
+        self,
+        name: str,
+        prompt_template: str,
+        dependencies: Optional[List[str]] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> HuggingFaceNode:
+        node = HuggingFaceNode(
+            name=name,
+            model=self.model,
+            prompt_template=prompt_template,
+            dependencies=dependencies,
+            stream=stream,
+            **kwargs,
+        )
+        self.dag.add_node(node)
+        return node
+
+    def optimize(self, options: Dict[str, Any]) -> None:
+        if "maxParallelCalls" in options:
+            self.scheduler.max_parallel_nodes = options["maxParallelCalls"]
+        if "maxExecutionTime" in options:
+            self.scheduler.max_execution_time = options["maxExecutionTime"]
+        if "priorityNodes" in options:
+            self.scheduler.priority_nodes = options["priorityNodes"]
+
+    async def execute(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        return await self.scheduler.execute(inputs)
+
+
+class HuggingFaceBatchProcessor:
+    """Process prompts with HuggingFace models in batches."""
+
+    def __init__(
+        self, model: Any, batch_size: int = 8, max_concurrent_batches: int = 2
+    ) -> None:
+        self.model = model
+        self.batch_size = batch_size
+        self.max_concurrent_batches = max_concurrent_batches
+
+    async def process(
+        self, prompts: List[str], process_fn: Callable[[str, Any], Any]
+    ) -> List[Any]:
+        batches = [
+            prompts[i : i + self.batch_size]
+            for i in range(0, len(prompts), self.batch_size)
+        ]
+        results: List[Any] = []
+        for i in range(0, len(batches), self.max_concurrent_batches):
+            current = batches[i : i + self.max_concurrent_batches]
+            tasks = [
+                asyncio.create_task(process_fn(p, self.model))
+                for batch in current
+                for p in batch
+            ]
+            batch_results = await asyncio.gather(*tasks, return_exceptions=True)
+            results.extend(r for r in batch_results if not isinstance(r, Exception))
+        return results
+

--- a/tygent/integrations/langsmith.py
+++ b/tygent/integrations/langsmith.py
@@ -1,0 +1,53 @@
+"""
+LangSmith Experiment Tracking Integration for Tygent.
+
+This module logs DAG execution results to LangSmith for experiment
+tracking and monitoring.
+"""
+
+from typing import Any, Dict, Optional, List
+
+try:
+    from langsmith import Client as LangSmithClient
+except Exception:  # pragma: no cover - langsmith may not be installed
+    LangSmithClient = None  # type: ignore
+
+
+class LangSmithTracker:
+    """Simple logger that sends DAG execution data to LangSmith."""
+
+    def __init__(self, client: Any) -> None:
+        if LangSmithClient is not None and isinstance(client, str):
+            self.client = LangSmithClient(api_key=client)
+        else:
+            self.client = client
+
+    async def log_run(
+        self,
+        dag_name: str,
+        inputs: Dict[str, Any],
+        outputs: Dict[str, Any],
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        if not self.client:
+            raise RuntimeError("LangSmith client is not configured")
+        try:
+            if hasattr(self.client, "create_run"):
+                await self.client.create_run(
+                    project_name=dag_name,
+                    run_type="tygent_dag",
+                    inputs=inputs,
+                    outputs=outputs,
+                    tags=tags or [],
+                )
+            elif hasattr(self.client, "log_run"):
+                await self.client.log_run(
+                    dag_name=dag_name,
+                    inputs=inputs,
+                    outputs=outputs,
+                    tags=tags or [],
+                )
+        except Exception as e:  # pragma: no cover - runtime errors
+            print(f"Failed to log execution to LangSmith: {e}")
+            raise
+

--- a/tygent/integrations/salesforce.py
+++ b/tygent/integrations/salesforce.py
@@ -37,6 +37,7 @@ class SalesforceNode(BaseNode):
         self.connection = connection
         self.operation_type = operation_type
         self.sobject = sobject
+        self.dependencies = dependencies or []
         self.kwargs = kwargs
 
     async def execute(
@@ -337,9 +338,15 @@ class SalesforceIntegration:
         constraints = constraints or {}
 
         # Configure the scheduler
-        max_parallel = constraints.get("max_concurrent_calls", 4)
-        max_time = constraints.get("max_execution_time", 60000)
-        priority_nodes = constraints.get("priority_nodes", [])
+        max_parallel = constraints.get(
+            "max_concurrent_calls", constraints.get("maxConcurrentCalls", 4)
+        )
+        max_time = constraints.get(
+            "max_execution_time", constraints.get("maxExecutionTime", 60000)
+        )
+        priority_nodes = constraints.get(
+            "priority_nodes", constraints.get("priorityNodes", [])
+        )
 
         # Apply configuration to scheduler
         self.scheduler.max_parallel_nodes = max_parallel
@@ -377,6 +384,7 @@ class TygentBatchProcessor:
         batch_size: int = 200,
         concurrent_batches: int = 3,
         error_handling: str = "continue",
+        **kwargs,
     ):
         """
         Initialize the batch processor.
@@ -387,6 +395,11 @@ class TygentBatchProcessor:
             concurrent_batches: Maximum number of concurrent batch executions
             error_handling: How to handle errors ("continue" or "abort")
         """
+        if "batchSize" in kwargs:
+            batch_size = kwargs.pop("batchSize")
+        if "concurrentBatches" in kwargs:
+            concurrent_batches = kwargs.pop("concurrentBatches")
+
         self.connection = connection
         self.batch_size = batch_size
         self.concurrent_batches = concurrent_batches


### PR DESCRIPTION
## Summary
- store Salesforce node dependencies and camelCase optimize options
- allow batchSize/concurrentBatches in `TygentBatchProcessor`
- add unit tests for Anthropic, HuggingFace Hub, and LangSmith integrations

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586b369418832ba2057fc5523972ad