### PR TITLE
Add parse-based acceleration

### DIFF
--- a/tests/integrations/test_performance.py
+++ b/tests/integrations/test_performance.py
@@ -1,0 +1,56 @@
+import asyncio
+import time
+import unittest
+
+import pytest
+
+from tygent.integrations.google_ai import GoogleAIIntegration, GoogleAINode
+from tygent.integrations.huggingface import HuggingFaceIntegration, HuggingFaceNode
+
+
+class DelayModel:
+    async def __call__(self, prompt, **kwargs):
+        await asyncio.sleep(0.1)
+        return f"out:{prompt}"
+
+    async def generateContent(self, prompt, **kwargs):
+        await asyncio.sleep(0.1)
+
+        class Resp:
+            def __init__(self, text):
+                self.text_content = text
+
+            @property
+            def response(self):
+                return self
+
+            def text(self):
+                return self.text_content
+
+        return Resp(f"resp:{prompt}")
+
+
+class TestIntegrationPerformance(unittest.TestCase):
+    @pytest.mark.asyncio
+    async def test_huggingface_parallel(self):
+        model = DelayModel()
+        integ = HuggingFaceIntegration(model)
+        integ.add_node("n1", "a {x}")
+        integ.add_node("n2", "b {x}")
+
+        start = time.perf_counter()
+        await integ.execute({"x": "y"})
+        parallel_time = time.perf_counter() - start
+        self.assertLess(parallel_time, 0.2)
+
+    @pytest.mark.asyncio
+    async def test_google_ai_parallel(self):
+        model = DelayModel()
+        integ = GoogleAIIntegration(model)
+        integ.addNode("g1", "hi {x}")
+        integ.addNode("g2", "bye {x}")
+
+        start = time.perf_counter()
+        await integ.execute({"x": "z"})
+        parallel_time = time.perf_counter() - start
+        self.assertLess(parallel_time, 0.2)

--- a/tests/test_accelerate.py
+++ b/tests/test_accelerate.py
@@ -1,0 +1,50 @@
+import asyncio
+import unittest
+
+from tygent import accelerate
+
+
+async def inc_fn(inputs):
+    return {"a": inputs.get("x", 0) + 1}
+
+
+async def double_fn(inputs):
+    return {"b": inputs.get("a", 0) * 2}
+
+
+class DummyFramework:
+    def get_plan(self):
+        return {
+            "name": "dummy",
+            "steps": [
+                {"name": "inc", "func": inc_fn},
+                {"name": "double", "func": double_fn, "dependencies": ["inc"]},
+            ],
+        }
+
+
+class TestAccelerate(unittest.TestCase):
+    def test_accelerate_plan(self):
+        plan = DummyFramework().get_plan()
+        accel = accelerate(plan)
+
+        async def run():
+            result = await accel.execute({"x": 2})
+            return result["results"]["double"]["b"]
+
+        value = asyncio.run(run())
+        self.assertEqual(value, 6)
+
+    def test_accelerate_framework(self):
+        accel = accelerate(DummyFramework())
+
+        async def run():
+            result = await accel.execute({"x": 3})
+            return result["results"]["double"]["b"]
+
+        value = asyncio.run(run())
+        self.assertEqual(value, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plan_parser.py
+++ b/tests/test_plan_parser.py
@@ -1,0 +1,34 @@
+import asyncio
+import unittest
+
+from tygent.plan_parser import parse_plan
+from tygent.scheduler import Scheduler
+
+
+async def add_fn(inputs):
+    return {"sum": inputs.get("a", 0) + inputs.get("b", 0)}
+
+
+async def mult_fn(inputs):
+    return {"product": inputs.get("sum", 0) * inputs.get("factor", 1)}
+
+
+class TestPlanParser(unittest.TestCase):
+    def test_parse_and_execute(self):
+        plan = {
+            "name": "math",
+            "steps": [
+                {"name": "add", "func": add_fn, "dependencies": [], "critical": True},
+                {"name": "mult", "func": mult_fn, "dependencies": ["add"]},
+            ],
+        }
+        dag, critical = parse_plan(plan)
+        scheduler = Scheduler(dag)
+        scheduler.priority_nodes = critical
+
+        async def run():
+            result = await scheduler.execute({"a": 2, "b": 3, "factor": 5})
+            return result["results"]["mult"]["product"]
+
+        value = asyncio.run(run())
+        self.assertEqual(value, 25)

--- a/tygent/__init__.py
+++ b/tygent/__init__.py
@@ -8,20 +8,22 @@ orchestration with optimized communication patterns.
 
 __version__ = "0.1.0"
 
-# Import core modules
-from .dag import DAG
-from .nodes import Node, LLMNode, ToolNode, BaseNode
-from .scheduler import Scheduler
-from .agent import Agent
-from .multi_agent import MultiAgentManager, CommunicationBus, Message
 from .accelerate import accelerate
 from .adaptive_executor import (
     AdaptiveExecutor,
     RewriteRule,
-    create_fallback_rule,
     create_conditional_branch_rule,
+    create_fallback_rule,
     create_resource_adaptation_rule,
 )
+from .agent import Agent
+
+# Import core modules
+from .dag import DAG
+from .multi_agent import CommunicationBus, Message, MultiAgentManager
+from .nodes import BaseNode, LLMNode, Node, ToolNode
+from .plan_parser import parse_plan
+from .scheduler import Scheduler
 
 __all__ = [
     "DAG",
@@ -40,4 +42,5 @@ __all__ = [
     "create_fallback_rule",
     "create_conditional_branch_rule",
     "create_resource_adaptation_rule",
+    "parse_plan",
 ]

--- a/tygent/dag.py
+++ b/tygent/dag.py
@@ -2,7 +2,8 @@
 Directed Acyclic Graph (DAG) implementation for Tygent.
 """
 
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
 from tygent.nodes import Node
 
 
@@ -171,3 +172,17 @@ class DAG:
         leaves = [name for name in self.nodes if not self.edges.get(name, [])]
 
         return roots, leaves
+
+    def copy(self) -> "DAG":
+        """Create a shallow copy of the DAG."""
+
+        new_dag = DAG(self.name)
+        # Copy nodes directly; nodes themselves remain the same instances
+        new_dag.nodes = dict(self.nodes)
+        # Copy edges and metadata
+        new_dag.edges = {k: list(v) for k, v in self.edges.items()}
+        new_dag.edge_mappings = {
+            src: {dst: dict(meta) for dst, meta in targets.items()}
+            for src, targets in self.edge_mappings.items()
+        }
+        return new_dag

--- a/tygent/plan_parser.py
+++ b/tygent/plan_parser.py
@@ -1,0 +1,61 @@
+"""Plan parser for generating DAGs from structured plans."""
+
+from typing import Any, Dict, List, Tuple
+
+from .dag import DAG
+from .nodes import ToolNode
+
+
+def parse_plan(plan: Dict[str, Any]) -> Tuple[DAG, List[str]]:
+    """Parse a plan dictionary into a :class:`~tygent.dag.DAG`.
+
+    The plan format is expected to be::
+
+        {
+            "name": "dag_name",
+            "steps": [
+                {
+                    "name": "step1",
+                    "func": callable,
+                    "dependencies": ["other_step"],
+                    "critical": True
+                },
+                ...
+            ]
+        }
+
+    ``critical`` steps are returned so the scheduler can prioritise them.
+
+    Parameters
+    ----------
+    plan:
+        Dictionary describing the plan.
+
+    Returns
+    -------
+    Tuple[DAG, List[str]]
+        The constructed DAG and list of critical node names.
+    """
+
+    dag_name = plan.get("name", "plan_dag")
+    dag = DAG(dag_name)
+    critical: List[str] = []
+
+    steps: List[Dict[str, Any]] = plan.get("steps", [])
+
+    # First create nodes
+    for step in steps:
+        node_name = step["name"]
+        func = step.get("func", lambda _inputs: None)
+        node = ToolNode(node_name, func)
+        dag.add_node(node)
+        if step.get("critical"):
+            critical.append(node_name)
+
+    # Then add edges
+    for step in steps:
+        node_name = step["name"]
+        for dep in step.get("dependencies", []):
+            dag.add_edge(dep, node_name)
+
+    return dag, critical


### PR DESCRIPTION
## Summary
- extend `accelerate()` so it can build DAGs from plans
- wrap frameworks exposing `get_plan`/`plan` using the new scheduler
- provide convenience executors used by `accelerate`
- add tests for plan and framework acceleration

## Testing
- `pip install -e .`
- `black .`
- `isort .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68588077c4e0832bb0f2a93b67c30f9b