### PR TITLE
Add latency model and latency-aware scheduling

### DIFF
--- a/tests/benchmarks/test_scheduler_perf.py
+++ b/tests/benchmarks/test_scheduler_perf.py
@@ -1,0 +1,77 @@
+import asyncio
+import time
+import unittest
+
+from tygent.dag import DAG
+from tygent.nodes import ToolNode
+from tygent.scheduler import Scheduler
+
+
+async def sleep_fn(delay: float, inputs):
+    await asyncio.sleep(delay)
+    return {"delay": delay}
+
+
+async def sequential_execute(dag: DAG) -> float:
+    order = dag.get_topological_order()
+    start = time.perf_counter()
+    outputs = {}
+    for name in order:
+        node = dag.getNode(name)
+        deps = {dep: outputs[dep] for dep in node.dependencies}
+        mapped = {}
+        for dep, out in deps.items():
+            if dep in dag.edge_mappings and name in dag.edge_mappings[dep]:
+                for src, tgt in dag.edge_mappings[dep][name].items():
+                    if src in out:
+                        mapped[tgt] = out[src]
+        inputs = mapped
+        res = await node.execute(inputs)
+        outputs[name] = res
+    time_taken = time.perf_counter() - start
+    return time_taken
+
+
+async def scheduler_execute(dag: DAG, **cfg) -> float:
+    scheduler = Scheduler(dag)
+    scheduler.configure(**cfg)
+    start = time.perf_counter()
+    await scheduler.execute({})
+    return time.perf_counter() - start
+
+
+class TestSchedulerBenchmarks(unittest.TestCase):
+    def _build_dag(self) -> DAG:
+        dag = DAG("bench")
+        dag.add_node(ToolNode("A", lambda i: sleep_fn(0.1, i), latency_estimate=0.1))
+        dag.add_node(ToolNode("B", lambda i: sleep_fn(0.2, i), latency_estimate=0.2))
+        dag.add_node(ToolNode("C", lambda i: sleep_fn(0.3, i), latency_estimate=0.3))
+        dag.add_node(ToolNode("D", lambda i: sleep_fn(0.1, i), latency_estimate=0.1))
+        dag.add_edge("A", "B")
+        dag.add_edge("A", "C")
+        dag.add_edge("B", "D")
+        dag.add_edge("C", "D")
+        return dag
+
+    def test_scheduler_vs_sequential(self):
+        dag = self._build_dag()
+        seq = asyncio.run(sequential_execute(dag))
+        par = asyncio.run(scheduler_execute(dag, max_parallel_nodes=2))
+        self.assertLess(par, seq)
+
+    def test_latency_aware_scheduler(self):
+        dag = self._build_dag()
+        normal = asyncio.run(scheduler_execute(dag, max_parallel_nodes=1))
+        latency = asyncio.run(
+            scheduler_execute(
+                dag,
+                max_parallel_nodes=2,
+                token_budget=10,
+                requests_per_minute=100,
+            )
+        )
+        self.assertLess(latency, normal)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_adaptive_executor.py
+++ b/tests/test_adaptive_executor.py
@@ -1,0 +1,41 @@
+import asyncio
+import unittest
+
+from tygent.adaptive_executor import AdaptiveExecutor, RewriteRule
+from tygent.dag import DAG
+from tygent.nodes import ToolNode
+
+
+class TestAdaptiveExecutor(unittest.TestCase):
+    def test_dag_copy_not_modified(self):
+        async def base_fn(inputs):
+            return {"x": 1}
+
+        async def new_fn(inputs):
+            return {"y": inputs.get("x", 0) + 1}
+
+        dag = DAG("base")
+        dag.add_node(ToolNode("base", base_fn))
+
+        def trigger(state):
+            return True
+
+        def action(current_dag, state):
+            new_dag = current_dag.copy()
+            new_dag.add_node(ToolNode("new", new_fn))
+            new_dag.add_edge("base", "new")
+            return new_dag
+
+        rule = RewriteRule(trigger, action, name="add_new")
+        executor = AdaptiveExecutor(dag, [rule], max_modifications=1)
+
+        async def run_test():
+            result = await executor.execute({})
+            self.assertEqual(len(dag.nodes), 1)  # original DAG unchanged
+            self.assertIn("new", result["final_dag"].nodes)
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -2,16 +2,18 @@
 Tests for the DAG module.
 """
 
-import unittest
 import asyncio
-import sys
 import os
+import sys
+import unittest
+from typing import List
 
 # Add the parent directory to the path so we can import tygent
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from tygent import Scheduler
 from tygent.dag import DAG
-from tygent.nodes import ToolNode, LLMNode
+from tygent.nodes import LLMNode, ToolNode
 
 
 class TestDAG(unittest.TestCase):
@@ -124,6 +126,186 @@ class TestExecution(unittest.TestCase):
             self.assertEqual(result["results"]["multiply"]["product"], 25)
 
         asyncio.run(run_test())
+
+    def test_dag_execute_helper(self):
+        """Test the DAG.execute convenience method."""
+
+        async def foo(inputs):
+            return {"out": inputs.get("val", 0) + 1}
+
+        async def run_test():
+            dag = DAG("helper")
+            dag.add_node(ToolNode("foo", foo))
+            result = await dag.execute({"val": 1})
+            self.assertEqual(result["results"]["foo"]["out"], 2)
+
+        asyncio.run(run_test())
+
+    def test_mixed_llm_and_tool_nodes(self):
+        """Ensure DAG executes mixed LLM and tool nodes in dependency order."""
+
+        class DummyLLMNode(LLMNode):
+            async def execute(self, inputs):
+                topic = inputs.get("topic", "")
+                return {"text": f"Info about {topic}"}
+
+        async def process(inputs):
+            return {"result": inputs.get("text", "").upper()}
+
+        async def run_test():
+            dag = DAG("mixed")
+            dag.add_node(DummyLLMNode("llm"))
+            dag.add_node(ToolNode("tool", process))
+            dag.add_edge("llm", "tool", {"text": "text"})
+
+            scheduler = Scheduler(dag)
+            result = await scheduler.execute({"topic": "AI"})
+
+            self.assertEqual(result["results"]["tool"]["result"], "INFO ABOUT AI")
+
+        asyncio.run(run_test())
+
+    def test_compute_critical_path_and_scheduler(self):
+        """Nodes with longer downstream latency should be prioritized."""
+
+        executed: List[str] = []
+
+        async def a_fn(inputs):
+            executed.append("A")
+            return {"A": True}
+
+        async def b_fn(inputs):
+            executed.append("B")
+            return {"B": True}
+
+        async def c_fn(inputs):
+            executed.append("C")
+            return {"C": True}
+
+        async def d_fn(inputs):
+            executed.append("D")
+            return {"D": True}
+
+        dag = DAG("cp")
+        dag.add_node(ToolNode("A", a_fn, latency_estimate=1))
+        dag.add_node(ToolNode("B", b_fn, latency_estimate=3))
+        dag.add_node(ToolNode("C", c_fn, latency_estimate=2))
+        dag.add_node(ToolNode("D", d_fn, latency_estimate=1))
+        dag.add_edge("A", "B")
+        dag.add_edge("A", "C")
+        dag.add_edge("B", "D")
+        dag.add_edge("C", "D")
+
+        cp = dag.compute_critical_path()
+        self.assertEqual(cp["D"], 1)
+        self.assertEqual(cp["B"], 4)
+        self.assertEqual(cp["C"], 3)
+        self.assertEqual(cp["A"], 5)
+
+        async def run_sched():
+            scheduler = Scheduler(dag)
+            scheduler.configure(max_parallel_nodes=1)
+            await scheduler.execute({})
+
+        asyncio.run(run_sched())
+        self.assertEqual(executed, ["A", "B", "C", "D"])
+
+    def test_latency_model_influences_schedule(self):
+        """Scheduler should use latency models when no fixed estimate is set."""
+
+        executed: List[str] = []
+
+        async def a_fn(inputs):
+            executed.append("A")
+            return {"A": True}
+
+        async def b_fn(inputs):
+            executed.append("B")
+            return {"B": True}
+
+        async def c_fn(inputs):
+            executed.append("C")
+            return {"C": True}
+
+        async def d_fn(inputs):
+            executed.append("D")
+            return {"D": True}
+
+        dag = DAG("model")
+
+        dag.add_node(ToolNode("A", a_fn, latency_model=lambda n: 1.0))
+        dag.add_node(ToolNode("B", b_fn, latency_model=lambda n: 3.0))
+        dag.add_node(ToolNode("C", c_fn, latency_model=lambda n: 2.0))
+        dag.add_node(ToolNode("D", d_fn, latency_model=lambda n: 1.0))
+
+        dag.add_edge("A", "B")
+        dag.add_edge("A", "C")
+        dag.add_edge("B", "D")
+        dag.add_edge("C", "D")
+
+        cp = dag.compute_critical_path()
+        self.assertEqual(cp["B"], 4.0)
+        self.assertEqual(cp["C"], 3.0)
+
+        async def run_sched():
+            scheduler = Scheduler(dag)
+            scheduler.configure(max_parallel_nodes=1)
+            await scheduler.execute({})
+
+        asyncio.run(run_sched())
+        self.assertEqual(executed, ["A", "B", "C", "D"])
+
+
+class TestSchedulerConstraints(unittest.TestCase):
+    """Tests for token budgets and rate limiting."""
+
+    def test_token_budget_exhaustion(self):
+        async def fn(inputs):
+            return {}
+
+        dag = DAG("budget")
+        dag.add_node(ToolNode("a", fn, token_cost=3))
+        dag.add_node(ToolNode("b", fn, token_cost=3))
+        dag.add_edge("a", "b")
+
+        scheduler = Scheduler(dag)
+        scheduler.configure(token_budget=5, max_parallel_nodes=1)
+
+        async def run():
+            await scheduler.execute({})
+
+        with self.assertRaises(RuntimeError):
+            asyncio.run(run())
+
+    def test_rate_limiting(self):
+        async def fn(inputs):
+            return {}
+
+        dag = DAG("rate")
+        dag.add_node(ToolNode("a", fn))
+        dag.add_node(ToolNode("b", fn))
+        dag.add_node(ToolNode("c", fn))
+        dag.add_edge("a", "b")
+        dag.add_edge("b", "c")
+
+        scheduler = Scheduler(dag)
+        scheduler.configure(max_parallel_nodes=1, requests_per_minute=1)
+
+        sleeps: List[float] = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        async def run():
+            original_sleep = asyncio.sleep
+            asyncio.sleep = fake_sleep
+            try:
+                await scheduler.execute({})
+            finally:
+                asyncio.sleep = original_sleep
+
+        asyncio.run(run())
+        self.assertTrue(len(sleeps) >= 1)
 
 
 if __name__ == "__main__":

--- a/tygent/nodes.py
+++ b/tygent/nodes.py
@@ -2,7 +2,19 @@
 Base node classes for Tygent.
 """
 
-from typing import Dict, List, Any, Optional, Callable, Union
+from typing import Any, Callable, Dict, List, Optional, Union
+
+
+def default_llm_latency_model(node: "LLMNode") -> float:
+    """Very rough latency estimate for LLM calls."""
+
+    return 0.5 + 0.01 * getattr(node, "token_cost", 0)
+
+
+def default_tool_latency_model(node: "ToolNode") -> float:
+    """Default latency for local tool calls."""
+
+    return 0.1
 
 
 class BaseNode:
@@ -34,14 +46,48 @@ class BaseNode:
 class Node(BaseNode):
     """Base node class for execution in the DAG."""
 
-    def __init__(self, name: str):
-        """
-        Initialize a node.
+    def __init__(
+        self,
+        name: str,
+        token_cost: int = 0,
+        latency_estimate: Optional[float] = None,
+        latency_model: Optional[Callable[["Node"], float]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        """Initialize a node.
 
-        Args:
-            name: The name of the node
+        Parameters
+        ----------
+        name : str
+            The name of the node.
+        token_cost : int, optional
+            Estimated token cost for executing this node.
+        latency_estimate : float, optional
+            Fixed latency estimate in seconds. If ``None`` a ``latency_model``
+            may be used to compute the value on demand.
+        latency_model : callable, optional
+            Function that accepts the node instance and returns an estimated
+            latency in seconds.
+        metadata : dict, optional
+            Arbitrary metadata for the node.
         """
         super().__init__(name)
+        self.token_cost = token_cost
+        self.latency_estimate = latency_estimate
+        self.latency_model = latency_model
+        self.metadata = metadata or {}
+
+    def get_latency_estimate(self) -> float:
+        """Return the estimated latency for this node."""
+
+        if self.latency_estimate is not None:
+            return float(self.latency_estimate)
+        if self.latency_model:
+            try:
+                return float(self.latency_model(self))
+            except Exception:
+                return 0.0
+        return 0.0
 
     def setDependencies(self, dependencies: List[str]) -> None:
         """
@@ -69,7 +115,14 @@ class LLMNode(Node):
     """Base class for LLM nodes."""
 
     def __init__(
-        self, name: str, model: Optional[Any] = None, prompt_template: str = ""
+        self,
+        name: str,
+        model: Optional[Any] = None,
+        prompt_template: str = "",
+        token_cost: int = 0,
+        latency_estimate: Optional[float] = None,
+        latency_model: Optional[Callable[["LLMNode"], float]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize an LLM node.
@@ -79,7 +132,16 @@ class LLMNode(Node):
             model: LLM model instance
             prompt_template: Template string for the prompt
         """
-        super().__init__(name)
+        if latency_model is None:
+            latency_model = default_llm_latency_model
+
+        super().__init__(
+            name,
+            token_cost=token_cost,
+            latency_estimate=latency_estimate,
+            latency_model=latency_model,
+            metadata=metadata,
+        )
         self.model = model
         self.prompt_template = prompt_template
 
@@ -87,7 +149,15 @@ class LLMNode(Node):
 class ToolNode(Node):
     """Tool node for executing functions."""
 
-    def __init__(self, name: str, func: Callable[[Dict[str, Any]], Any]):
+    def __init__(
+        self,
+        name: str,
+        func: Callable[[Dict[str, Any]], Any],
+        token_cost: int = 0,
+        latency_estimate: Optional[float] = None,
+        latency_model: Optional[Callable[["ToolNode"], float]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
         """
         Initialize a tool node.
 
@@ -95,7 +165,16 @@ class ToolNode(Node):
             name: The name of the node
             func: The function to execute
         """
-        super().__init__(name)
+        if latency_model is None:
+            latency_model = default_tool_latency_model
+
+        super().__init__(
+            name,
+            token_cost=token_cost,
+            latency_estimate=latency_estimate,
+            latency_model=latency_model,
+            metadata=metadata,
+        )
         self.func = func
 
     async def execute(self, inputs: Dict[str, Any]) -> Any:


### PR DESCRIPTION
## Summary
- support optional latency models in Node and subclasses
- compute critical path using `get_latency_estimate`
- provide default latency models for LLM and tool nodes
- test that latency models influence scheduling order
- add scheduler benchmarks and document typical results

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685875c47bd0832ba726600f46a07f77