### PR TITLE
Enable decorator form for accelerate

### DIFF
--- a/tests/test_accelerate.py
+++ b/tests/test_accelerate.py
@@ -45,6 +45,14 @@ class TestAccelerate(unittest.TestCase):
         value = asyncio.run(run())
         self.assertEqual(value, 8)
 
+    def test_accelerate_decorator(self):
+        @accelerate
+        async def add_one(x):
+            return x + 1
+
+        result = add_one(4)
+        self.assertEqual(result, 5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tygent/accelerate.py
+++ b/tygent/accelerate.py
@@ -11,7 +11,9 @@ from .plan_parser import parse_plan
 from .scheduler import Scheduler
 
 
-def accelerate(func_or_agent: Union[Callable, Any]) -> Union[Callable, Any]:
+def accelerate(
+    func_or_agent: Optional[Union[Callable, Any]] = None,
+) -> Union[Callable, Any]:
     """
     Accelerate any function or agent framework for automatic parallel optimization.
 
@@ -19,11 +21,19 @@ def accelerate(func_or_agent: Union[Callable, Any]) -> Union[Callable, Any]:
     optimizes execution through parallel processing and DAG-based scheduling.
 
     Args:
-        func_or_agent: Function, agent, or framework object to accelerate
+        func_or_agent: Function, agent, or framework object to accelerate. If ``None``,
+            ``accelerate`` returns a decorator that can be applied using ``@accelerate()``.
 
     Returns:
         Accelerated version with same interface but optimized execution
     """
+
+    if func_or_agent is None:
+
+        def decorator(inner: Union[Callable, Any]) -> Union[Callable, Any]:
+            return accelerate(inner)
+
+        return decorator
 
     # Directly parse plan dictionaries
     if isinstance(func_or_agent, dict) and "steps" in func_or_agent:


### PR DESCRIPTION
## Summary
- allow `accelerate` to be used as `@accelerate()` by making the argument optional
- add unit test to cover decorator usage

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e91c4c7c832b86c8e9a710e98384