### PR TITLE
Support merging multiple plans into a single DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ scheduler.priority_nodes = critical
 run_plan = accelerate(plan)
 ```
 
+If you have multiple plans (e.g. produced by different LLMs) you can
+combine them into a single DAG:
+
+```python
+from tygent import parse_plans, Scheduler
+
+dag, critical = parse_plans([plan_a, plan_b])
+scheduler = Scheduler(dag)
+scheduler.priority_nodes = critical
+```
+
 ## Testing
 
 ### Running Tests

--- a/tests/test_plan_parser.py
+++ b/tests/test_plan_parser.py
@@ -1,7 +1,7 @@
 import asyncio
 import unittest
 
-from tygent.plan_parser import parse_plan
+from tygent.plan_parser import parse_plan, parse_plans
 from tygent.scheduler import Scheduler
 
 
@@ -11,6 +11,14 @@ async def add_fn(inputs):
 
 async def mult_fn(inputs):
     return {"product": inputs.get("sum", 0) * inputs.get("factor", 1)}
+
+
+async def inc_fn(inputs):
+    return {"num": inputs.get("x", 0) + 1}
+
+
+async def double_fn(inputs):
+    return {"double": inputs.get("num", 0) * 2}
 
 
 class TestPlanParser(unittest.TestCase):
@@ -32,3 +40,35 @@ class TestPlanParser(unittest.TestCase):
 
         value = asyncio.run(run())
         self.assertEqual(value, 25)
+
+    def test_parse_multiple_plans(self):
+        plan1 = {
+            "name": "math",
+            "steps": [
+                {"name": "add", "func": add_fn},
+                {"name": "mult", "func": mult_fn, "dependencies": ["add"]},
+            ],
+        }
+
+        plan2 = {
+            "name": "proc",
+            "steps": [
+                {"name": "inc", "func": inc_fn},
+                {"name": "double", "func": double_fn, "dependencies": ["inc"]},
+            ],
+        }
+
+        dag, critical = parse_plans([plan1, plan2])
+        scheduler = Scheduler(dag)
+        scheduler.priority_nodes = critical
+
+        async def run():
+            result = await scheduler.execute({"a": 2, "b": 3, "factor": 5, "x": 4})
+            return (
+                result["results"]["mult"]["product"],
+                result["results"]["double"]["double"],
+            )
+
+        mult_val, double_val = asyncio.run(run())
+        self.assertEqual(mult_val, 25)
+        self.assertEqual(double_val, 10)

--- a/tygent/__init__.py
+++ b/tygent/__init__.py
@@ -23,7 +23,7 @@ from .dag import DAG
 from .multi_agent import CommunicationBus, Message, MultiAgentManager
 from .nodes import BaseNode, LLMNode, Node, ToolNode
 from .patch import install
-from .plan_parser import parse_plan
+from .plan_parser import parse_plan, parse_plans
 from .scheduler import Scheduler
 
 __all__ = [
@@ -44,5 +44,6 @@ __all__ = [
     "create_conditional_branch_rule",
     "create_resource_adaptation_rule",
     "parse_plan",
+    "parse_plans",
     "install",
 ]

--- a/tygent/plan_parser.py
+++ b/tygent/plan_parser.py
@@ -1,6 +1,6 @@
 """Plan parser for generating DAGs from structured plans."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 from .dag import DAG
 from .nodes import ToolNode
@@ -59,3 +59,41 @@ def parse_plan(plan: Dict[str, Any]) -> Tuple[DAG, List[str]]:
             dag.add_edge(dep, node_name)
 
     return dag, critical
+
+
+def parse_plans(plans: Iterable[Dict[str, Any]]) -> Tuple[DAG, List[str]]:
+    """Combine multiple plan dictionaries into a single DAG.
+
+    Parameters
+    ----------
+    plans:
+        Iterable of plan dictionaries in the same format accepted by
+        :func:`parse_plan`.
+
+    Returns
+    -------
+    Tuple[DAG, List[str]]
+        Merged DAG and combined list of critical node names.
+    """
+
+    merged = DAG("combined_plan")
+    critical_all: List[str] = []
+
+    for plan in plans:
+        dag, critical = parse_plan(plan)
+
+        # Add nodes
+        for node in dag.nodes.values():
+            if merged.hasNode(node.name):
+                raise ValueError(f"Duplicate node name {node.name} in plans")
+            merged.add_node(node)
+
+        # Add edges with metadata
+        for src, targets in dag.edges.items():
+            for tgt in targets:
+                meta = dag.edge_mappings.get(src, {}).get(tgt)
+                merged.add_edge(src, tgt, meta)
+
+        critical_all.extend(critical)
+
+    return merged, critical_all


### PR DESCRIPTION
## Summary
- add `parse_plans` helper for merging multiple plan dictionaries
- expose `parse_plans` in public API
- document plan merging in README
- test merging of multiple plans

## Testing
- `pip install -e .`
- `black tests/test_plan_parser.py tygent/__init__.py tygent/plan_parser.py`
- `isort tests/test_plan_parser.py tygent/__init__.py tygent/plan_parser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865907ddae8832bbc5c75dcc089bafa