### PR TITLE
Add formatting checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-asyncio
+        pip install isort black
         pip install -e .
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-asyncio
         pip install -e .
+
+    - name: Check formatting
+      run: |
+        isort --check-only .
+        black --check .
     
     - name: Run core tests
       run: |

--- a/tests/integrations/test_anthropic.py
+++ b/tests/integrations/test_anthropic.py
@@ -1,11 +1,13 @@
 """Tests for Anthropic integration."""
 
 import unittest
+
 import pytest
+
 from tygent.integrations.anthropic import (
-    AnthropicNode,
-    AnthropicIntegration,
     AnthropicBatchProcessor,
+    AnthropicIntegration,
+    AnthropicNode,
 )
 
 

--- a/tests/integrations/test_google_ai.py
+++ b/tests/integrations/test_google_ai.py
@@ -3,13 +3,15 @@ Tests for Google AI integration with Tygent.
 """
 
 import asyncio
-import pytest
 import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from tygent.integrations.google_ai import (
-    GoogleAINode,
-    GoogleAIIntegration,
     GoogleAIBatchProcessor,
+    GoogleAIIntegration,
+    GoogleAINode,
 )
 
 

--- a/tests/integrations/test_huggingface.py
+++ b/tests/integrations/test_huggingface.py
@@ -1,11 +1,13 @@
 """Tests for HuggingFace integration."""
 
 import unittest
+
 import pytest
+
 from tygent.integrations.huggingface import (
-    HuggingFaceNode,
-    HuggingFaceIntegration,
     HuggingFaceBatchProcessor,
+    HuggingFaceIntegration,
+    HuggingFaceNode,
 )
 
 

--- a/tests/integrations/test_langsmith.py
+++ b/tests/integrations/test_langsmith.py
@@ -1,7 +1,9 @@
 """Tests for LangSmith tracker."""
 
 import unittest
+
 import pytest
+
 from tygent.integrations.langsmith import LangSmithTracker
 
 

--- a/tests/integrations/test_microsoft_ai.py
+++ b/tests/integrations/test_microsoft_ai.py
@@ -3,12 +3,14 @@ Tests for Microsoft AI integration with Tygent.
 """
 
 import asyncio
-import pytest
 import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from tygent.integrations.microsoft_ai import (
-    MicrosoftAINode,
     MicrosoftAIIntegration,
+    MicrosoftAINode,
     SemanticKernelOptimizer,
 )
 

--- a/tests/integrations/test_salesforce.py
+++ b/tests/integrations/test_salesforce.py
@@ -3,12 +3,14 @@ Tests for Salesforce integration with Tygent.
 """
 
 import asyncio
-import pytest
 import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from tygent.integrations.salesforce import (
-    SalesforceNode,
     SalesforceIntegration,
+    SalesforceNode,
     TygentBatchProcessor,
 )
 

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -2,18 +2,18 @@
 Fixed tests for the multi-agent module that match the actual implementation.
 """
 
-import unittest
-from unittest.mock import AsyncMock
 import asyncio
-import time
-import sys
 import os
+import sys
+import time
+import unittest
 import uuid
+from unittest.mock import AsyncMock
 
 # Add the parent directory to the path so we can import tygent
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from tygent.multi_agent import Message, CommunicationBus, MultiAgentManager
+from tygent.multi_agent import CommunicationBus, Message, MultiAgentManager
 
 
 class TestMessage(unittest.TestCase):

--- a/tygent/adaptive_executor.py
+++ b/tygent/adaptive_executor.py
@@ -4,6 +4,7 @@ Adaptive Executor with dynamic DAG modification capabilities.
 
 import asyncio
 from typing import Any, Callable, Dict, List, Optional, Union
+
 from .dag import DAG
 from .scheduler import Scheduler
 

--- a/tygent/agent.py
+++ b/tygent/agent.py
@@ -2,7 +2,7 @@
 Agent implementation for Tygent.
 """
 
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
 
 
 class Agent:

--- a/tygent/integrations/crewai.py
+++ b/tygent/integrations/crewai.py
@@ -150,4 +150,3 @@ def tygent_crew(crew: Any):
         return wrapper
 
     return decorator
-

--- a/tygent/integrations/langflow.py
+++ b/tygent/integrations/langflow.py
@@ -45,7 +45,9 @@ class LangflowNode(BaseNode):
 class LangflowIntegration:
     """Execute Langflow workflows using a DAG and scheduler."""
 
-    def __init__(self, flow_data: Dict[str, Any], base_url: str = "http://localhost:7860"):
+    def __init__(
+        self, flow_data: Dict[str, Any], base_url: str = "http://localhost:7860"
+    ):
         self.flow_data = flow_data
         self.flow_id = flow_data.get("id", "flow")
         self.base_url = base_url.rstrip("/")
@@ -70,7 +72,9 @@ class LangflowIntegration:
                 self.dag.add_edge(src, tgt)
 
     # ------------------------------------------------------------------
-    def optimize(self, options: Optional[Dict[str, Any]] = None) -> "LangflowIntegration":
+    def optimize(
+        self, options: Optional[Dict[str, Any]] = None
+    ) -> "LangflowIntegration":
         options = options or {}
         if "maxParallelCalls" in options:
             self.scheduler.max_parallel_nodes = options["maxParallelCalls"]
@@ -88,7 +92,9 @@ class LangflowIntegration:
 # Convenience helpers
 
 
-def accelerate_langflow_flow(flow_data: Dict[str, Any], base_url: str = "http://localhost:7860") -> LangflowIntegration:
+def accelerate_langflow_flow(
+    flow_data: Dict[str, Any], base_url: str = "http://localhost:7860"
+) -> LangflowIntegration:
     """Return a :class:`LangflowIntegration` for the supplied flow."""
     return LangflowIntegration(flow_data, base_url)
 
@@ -146,4 +152,3 @@ def tygent_langflow(flow_data: Dict[str, Any], base_url: str = "http://localhost
         return wrapper
 
     return decorator
-

--- a/tygent/integrations/langsmith.py
+++ b/tygent/integrations/langsmith.py
@@ -5,7 +5,7 @@ This module logs DAG execution results to LangSmith for experiment
 tracking and monitoring.
 """
 
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 try:
     from langsmith import Client as LangSmithClient
@@ -50,4 +50,3 @@ class LangSmithTracker:
         except Exception as e:  # pragma: no cover - runtime errors
             print(f"Failed to log execution to LangSmith: {e}")
             raise
-

--- a/tygent/multi_agent.py
+++ b/tygent/multi_agent.py
@@ -2,10 +2,10 @@
 Multi-agent implementation for Tygent.
 """
 
-from typing import Dict, List, Any, Optional, TypedDict
 import asyncio
 import time
 import uuid
+from typing import Any, Dict, List, Optional, TypedDict
 
 
 class Message(TypedDict):


### PR DESCRIPTION
## Summary
- reorder imports with isort and reformat code with black
- check code formatting in CI before running tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668be0b75c83279c5d59b67a1df190