### PR TITLE
Fix accelerate loop handling

### DIFF
--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -47,3 +47,9 @@ for name, duration, success, improvement in results:
     if improvement is not None:
         line += f", {improvement:.1f}% faster"
     print(line)
+
+failed = any(
+    duration is not None and not success for _, duration, success, _ in results
+)
+if failed:
+    sys.exit(1)

--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -14,7 +14,9 @@ SKIP_REQUIREMENTS = {
     "salesforce_example.py": "SALESFORCE_USERNAME",
 }
 
-OPTIONAL_MODULES = {"langgraph_integration.py": ["langgraph", "langchain"]}
+OPTIONAL_MODULES = {
+    "langgraph_integration.py": ["langgraph", "langchain", "langchain_community"]
+}
 
 results = []
 

--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -14,6 +14,8 @@ SKIP_REQUIREMENTS = {
     "salesforce_example.py": "SALESFORCE_USERNAME",
 }
 
+OPTIONAL_MODULES = {"langgraph_integration.py": "langchain"}
+
 results = []
 
 for example in sorted(EXAMPLES_DIR.glob("*.py")):
@@ -22,6 +24,15 @@ for example in sorted(EXAMPLES_DIR.glob("*.py")):
         print(f"Skipping {example.name} (missing {env_var})")
         results.append((example.name, None, False, None))
         continue
+
+    module_name = OPTIONAL_MODULES.get(example.name)
+    if module_name:
+        from importlib.util import find_spec
+
+        if find_spec(module_name) is None:
+            print(f"Skipping {example.name} (missing {module_name})")
+            results.append((example.name, None, False, None))
+            continue
 
     print(f"Running {example.name}...")
     start = time.perf_counter()

--- a/tests/test_accelerate.py
+++ b/tests/test_accelerate.py
@@ -53,6 +53,20 @@ class TestAccelerate(unittest.TestCase):
         result = add_one(4)
         self.assertEqual(result, 5)
 
+    def test_accelerate_in_running_loop(self):
+        @accelerate
+        async def add_one(x):
+            await asyncio.sleep(0)
+            return x + 1
+
+        async def run():
+            coro = add_one(5)
+            self.assertTrue(asyncio.iscoroutine(coro))
+            return await coro
+
+        value = asyncio.run(run())
+        self.assertEqual(value, 6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tygent/accelerate.py
+++ b/tygent/accelerate.py
@@ -108,8 +108,7 @@ def _accelerate_function(func: Callable) -> Callable:
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        # For simple functions, analyze if they contain multiple async calls
-        # that can be parallelized
+        # For simple functions, analyze if they contain multiple async calls that can be parallelized
         if asyncio.iscoroutinefunction(func):
             return _optimize_async_function(func, args, kwargs)
         else:
@@ -121,8 +120,17 @@ def _accelerate_function(func: Callable) -> Callable:
 def _optimize_async_function(func: Callable, args: tuple, kwargs: dict) -> Any:
     """Optimize async function execution by identifying parallel opportunities."""
 
-    # Run the original function for now, with potential for future DAG optimization
-    return asyncio.run(func(*args, **kwargs))
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        # Already inside an event loop; return coroutine for the caller to await
+        return func(*args, **kwargs)
+    else:
+        # No running event loop, execute and return result synchronously
+        return asyncio.run(func(*args, **kwargs))
 
 
 def _optimize_sync_function(func: Callable, args: tuple, kwargs: dict) -> Any:


### PR DESCRIPTION
## Summary
- improve async detection in `accelerate` helper so calls within running event loops return a coroutine instead of raising
- revert accidental changes to `langgraph_integration.py`

## Testing
- `pytest -q`
- `python scripts/benchmark_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_686b19cbeab88327884b87808fd53850